### PR TITLE
Resolves ropensci/aorsf#29

### DIFF
--- a/src/orsf_oop.cpp
+++ b/src/orsf_oop.cpp
@@ -499,3 +499,19 @@
    return(result);
 
  }
+ 
+ 
+ // [[Rcpp::export]]
+ double compute_var_reduction(arma::vec& y_node, 
+                              arma::vec& w_node, 
+                              arma::uvec& g_node){
+   arma::vec w_left = w_node % (1 - g_node);
+   arma::vec w_right = w_node % g_node;
+   double root_mean = sum(y_node % w_node)/sum(w_node);
+   double left_mean = sum(y_node % w_left)/sum(w_left);
+   double right_mean = sum(y_node % w_right)/sum(w_right);
+   
+   return (sum(w_node % pow(y_node - root_mean, 2)) - sum(w_left % pow(y_node - left_mean, 2)) -
+           sum(w_right % pow(y_node - right_mean, 2)))/sum(w_node);
+ }
+ 

--- a/tests/testthat/test-compute_var_reduction.R
+++ b/tests/testthat/test-compute_var_reduction.R
@@ -1,0 +1,38 @@
+
+# R version written using matrixStats
+var_reduction_R <- function(y, w, g){
+  (sum(w) - 1)/sum(w) * matrixStats::weightedVar(y, w = w) - 
+    (sum(w*g) - 1)/(sum(w))*matrixStats::weightedVar(y, w = w, idxs = which(g == 1)) -
+    (sum(w*(1-g)) - 1)/(sum(w))*matrixStats::weightedVar(y, w = w, idxs = which(g == 0))
+}
+
+test_that(
+  desc = 'computed variance reduction close to matrixStats::weightedVar',
+  code = {
+    
+    n_runs <- 100
+    
+    diffs_vec <- vector(mode = 'numeric', length = n_runs)
+    
+    for(i in seq(n_runs)){
+      
+      y <- rnorm(100)
+      w <- runif(100, 0, 2)
+      g <- rbinom(100, 1, 0.5)
+      diffs_vec[i] <- abs(compute_var_reduction(y, w, g) - 
+                            var_reduction_R(y, w, g))
+    }
+    
+    # unweighted is basically identical to cstat from survival
+    expect_lt(mean(diffs_vec), 1e-6)
+  }
+)
+
+
+# # The cpp implementation is 80+ times faster than the implementation using
+# # matrixStats::weightedVar
+# microbenchmark::microbenchmark(
+#   cpp = compute_var_reduction(y, w, g),
+#   r = var_reduction_R(y, w, g),
+#   times = 10000
+# )


### PR DESCRIPTION
This adds a `compute_var_reduction` function in `orsf_oop.cpp` to compute the variance reduction after a possible split, allowing for weights. The function is evaluated for correctness and speed in `test-compute_var_reduction.R`.

Given vectors $y$ (the response values), $w$ (the weights), and $g$ (the group assignments -- 0 = left, 1 = right), the weighted reduction in variance is

```math
\Delta = \frac{1}{\sum \limits_{i=1}^n w_i} \left(\sum \limits_{i=1}^n w_i (y_i - \overline{y}_{node})^2 - \sum \limits_{i=1}^n  w_i (1 - g_i)(y_i - \overline{y}_{left})^2 - \sum \limits_{i=1}^n  w_i g_i(y_i - \overline{y}_{right})^2  \right)
```

where 

```math
\overline{y}_{node} = \frac{ \sum \limits_{i=1}^n w_i y_i}{\sum \limits_{i=1}^n w_i} \hspace{1cm} \overline{y}_{left} = \frac{ \sum \limits_{i=1}^n w_i (1-g_i) y_i}{\sum \limits_{i=1}^n w_i(1-g_i)} \hspace{1cm} \overline{y}_{right} = \frac{ \sum \limits_{i=1}^n w_i g_i y_i}{\sum \limits_{i=1}^n w_i g_i}
```