### PR TITLE
Add missing dep for vignette building

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
     glmnet,
     covr,
     units,
-    tibble
+    tibble,
+    tidyverse
 Config/testthat/edition: 3
 VignetteBuilder: knitr


### PR DESCRIPTION
We see a docs building failure on https://ropensci.r-universe.dev/builds

I'd recommend running `desc::desc_normalize()` to have the dependencies alphabetically ordered :nail_care: (really a detail)