### PR TITLE
Do not specify CXXSTD for recent R versions

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,5 +1,2 @@
-# This file will only be used on R < 4.2.
-# Newer versions of R will prefer Makevars.ucrt
-CXX_STD = CXX14
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
This should get rid of the NOTE in CMD check so that you don't have to argue with CRAN.

The trick here is that recent versions of R will use `Makevars.ucrt` instead of `Makevars.win` if it exists. So this way we only specify `CXX_STD = CXX14` on R verions where it is needed.

Tested to work with R 4.0 - 4.4.