### PR TITLE
fix vi value change

### DIFF
--- a/R/orsf_R6.R
+++ b/R/orsf_R6.R
@@ -974,11 +974,23 @@ ObliqueForest <- R6::R6Class(
   },
 
   get_importance_clean = function(importance_raw = NULL,
-                                  group_factors = NULL){
+                                  group_factors = NULL,
+                                  overwrite = TRUE){
 
 
    input <- importance_raw %||% private$importance_raw
    group_factors <- group_factors %||% self$group_factors
+
+   # if an oblique forest is fit with anova, then a user
+   # asks to use the same forest to compute oobag permutation
+   # importance, we don't want to overwrite the initial importance
+   # values in the forest, so we return the cleaned importance values.
+   if(!overwrite){
+    return(private$clean_importance(input,
+                                    group_factors,
+                                    overwrite = overwrite))
+   }
+
    private$clean_importance(input, group_factors)
 
    return(self$importance)
@@ -3288,7 +3300,9 @@ ObliqueForest <- R6::R6Class(
 
   # cleaners
 
-  clean_importance = function(importance = NULL, group_factors = NULL){
+  clean_importance = function(importance = NULL,
+                              group_factors = NULL,
+                              overwrite = TRUE){
 
    out <- importance %||% self$importance
    group_factors <- group_factors %||% self$importance_group_factors
@@ -3334,6 +3348,10 @@ ObliqueForest <- R6::R6Class(
 
     }
 
+   }
+
+   if(!overwrite){
+    return(rev(out[order(out), , drop=TRUE]))
    }
 
    self$importance <- rev(out[order(out), , drop=TRUE])

--- a/R/orsf_vi.R
+++ b/R/orsf_vi.R
@@ -260,7 +260,7 @@ orsf_vi_ <- function(object,
                              n_thread, verbose_progress)
  )
 
- object$get_importance_clean(out, group_factors)
+ object$get_importance_clean(out, group_factors, overwrite = FALSE)
 
 }
 

--- a/tests/testthat/test-orsf_vi.R
+++ b/tests/testthat/test-orsf_vi.R
@@ -498,4 +498,23 @@ test_that(
  }
 )
 
+test_that(
+ desc = 'calling convenience vi functions does not change forest data',
+ code = {
+
+  importance_init <- fit_standard_pbc$fast$importance
+  importance_type_init <- fit_standard_pbc$fast$importance_type
+
+  importance_permute <- orsf_vi_permute(fit_standard_pbc$fast)
+
+  expect_equal(importance_init, fit_standard_pbc$fast$importance)
+  expect_equal(importance_type_init, fit_standard_pbc$fast$importance_type)
+
+  importance_negate <- orsf_vi_negate(fit_standard_pbc$fast)
+
+  expect_equal(importance_init, fit_standard_pbc$fast$importance)
+  expect_equal(importance_type_init, fit_standard_pbc$fast$importance_type)
+
+ }
+)
 


### PR DESCRIPTION
cleaner function for variable importance was overwriting values, which is intended on first use, but not helpful if user is calling a convenience function like `orsf_vi_permute` on a forest that was initially fit with anova importance.