### PR TITLE
Avoid stats::terms for formulas

### DIFF
--- a/R/get_predictors.R
+++ b/R/get_predictors.R
@@ -1,0 +1,73 @@
+
+
+#' Get predictors from a formula
+#'
+#' @param formula a `formula` object
+#' @param outcomes a character vector containing names of outcome
+#'  variable(s) in `formula`
+#' @param data the data where `formula` will be evaluated.
+#'
+#' @return a character vector of predictors in `formula`
+#' @noRd
+#'
+#' @examples
+#'
+#' f <- a ~ b + c
+#' get_predictors(f, outcomes = 'a')
+#'
+#' data_example <- matrix(0, ncol = length(letters))
+#' colnames(data_example) <- letters
+#' data_example <- as.data.frame(data_example)
+#' f <- a + b ~ . - z
+#'
+#' get_predictors(f, outcomes = c("a", "b"), data = data_example)
+#'
+get_predictors <- function(formula,
+                           outcomes = NULL,
+                           data = NULL) {
+
+ stopifnot(inherits(formula, "formula"))
+
+ if(!is.null(data)){
+  stopifnot(is.data.frame(data))
+ }
+
+ if(!is.null(outcomes)){
+  stopifnot(is.character(outcomes))
+ }
+
+ # parse to a character valued vector
+ formula_chr <- as.character(formula)
+ # Right-hand side
+ rhs <- formula_chr[length(formula_chr)]
+
+ # Split RHS by '+' and '-' to get variable names and operations
+ # Add spaces around operators to help splitting
+ rhs_spaced <- gsub("([+-])", " \\1 ", rhs)
+ tokens <- unlist(strsplit(rhs_spaced, "\\s+"))
+ tokens <- tokens[tokens != ""]  # Remove empty elements
+
+ # Handle '.' if present
+ if ("." %in% tokens) {
+
+  if (is.null(data))
+   stop("Formula contains '.' but 'data' was not provided.",
+        call. = FALSE)
+
+  # Exclude response variable
+  dot_vars <- setdiff(names(data), outcomes)
+
+  # Replace '.' with actual variable names
+  dot_index <- which(tokens == ".")
+  tokens <- append(tokens, dot_vars, after = dot_index)
+
+  # Remove the '.'
+  tokens <- tokens[-dot_index]
+
+ }
+
+ drop_vars <- tokens[which(tokens == '-') + 1]
+
+ unique(setdiff(tokens, c("+", "-", drop_vars)))
+
+}

--- a/R/orsf_R6.R
+++ b/R/orsf_R6.R
@@ -2329,15 +2329,13 @@ ObliqueForest <- R6::R6Class(
 
    if(!is.null(data)) self$data <- data
 
-   formula_terms <- suppressWarnings(
-    stats::terms(x = self$formula, data = self$data)
-   )
-
-   if(attr(formula_terms, 'response') == 0)
+   if(length(self$formula) < 3)
     stop("formula should have a response", call. = FALSE)
 
-   names_x_data <- attr(formula_terms, 'term.labels')
    names_y_data <- all.vars(self$formula[[2]])
+   names_x_data <- get_predictors(self$formula,
+                                  outcomes = names_y_data,
+                                  data = self$data)
 
    # check factors in x data
    fctr_check(self$data, names_x_data)


### PR DESCRIPTION
fixes #71

Instead of `stats::terms()`, use a formula parsing function that won't encounter memory issues with larger datasets.